### PR TITLE
Upgrade dependency to Spring Social 1.1.0.M4; Upgrade to Jackson 2; Add support for...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@
 // Configuration for the root project
 // -----------------------------------------------------------------------------
 description = 'Spring Social Instagram'
-abbreviation = 'SOCIAL-INSTAGRAM'
 
 apply plugin: 'base'
 apply plugin: 'idea'
@@ -51,9 +50,9 @@ allprojects {
 
     // default set of maven repositories to be used when resolving dependencies
     repositories {
-        mavenRepo urls: 'http://maven.springframework.org/release'
-        mavenRepo urls: 'http://maven.springframework.org/milestone'
-        mavenRepo urls: 'http://maven.springframework.org/snapshot'
+        maven { url 'http://repo.spring.io/release' }
+        maven { url 'http://repo.spring.io/milestone' }
+        maven { url 'http://repo.spring.io/snapshot' }
         mavenCentral()
     }
 }
@@ -67,7 +66,7 @@ allprojects {
 // @see configure(*) sections below
 // -----------------------------------------------------------------------------
 
-javaprojects = subprojects.findAll { project ->
+ext.javaprojects = subprojects.findAll { project ->
     project.path.startsWith(':spring-social-')
 }
 
@@ -81,24 +80,25 @@ configure(javaprojects) {
     apply plugin: 'eclipse' // `gradle eclipse` to generate .classpath/.project
     apply plugin: 'idea' // `gradle idea` to generate .ipr/.iml
 
-    // set up dedicated directories for jars and source jars.
-    // this makes it easier when putting together the distribution
-    libsBinDir = new File(libsDir, 'bin')
-    libsSrcDir = new File(libsDir, 'src')
-
+    ext {
+        // set up dedicated directories for jars and source jars.
+        // this makes it easier when putting together the distribution
+        libsBinDir = new File(libsDir, 'bin')
+        libsSrcDir = new File(libsDir, 'src')
+        
+        springSocialVersion = '1.1.0.M4'
+        springVersion = '4.0.1.RELEASE'
+        jacksonVersion = '2.2.2'
+        junitVersion = '4.11'
+        mockitoVersion = '1.9.5'
+        springVersion = '4.0.1.RELEASE'
+    }
+    
     // add tasks for creating source jars and generating poms etc
     apply from: "$buildSrcDir/maven-deployment.gradle"
 
     // add tasks for finding and publishing .xsd files
     apply from: "$buildSrcDir/schema-publication.gradle"
-
-    springSocialVersion = '1.0.0.RELEASE'
-    jacksonVersion = '1.8.5'
-    jspApiVersion = '2.1'
-    junitVersion = '4.9'
-    mockitoVersion = '1.8.5'
-    servletApiVersion = '2.5'
-    springVersion = '3.1.0.M2'
 
     sourceSets {
         main {
@@ -124,7 +124,7 @@ configure(javaprojects) {
     [compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:all']
 
     // generate .classpath files without GRADLE_CACHE variable (GRADLE-1079)
-    eclipseClasspath.variables = [:]
+    eclipse.pathVariables = [:]
 }
 
 
@@ -138,10 +138,8 @@ project('spring-social-instagram') {
     description = 'Instagram API'
     dependencies {
         compile "org.springframework.social:spring-social-core:$springSocialVersion"
-        compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
-        compile ("javax.servlet:servlet-api:$servletApiVersion") { provided = true }
-        compile ("javax.servlet.jsp:jsp-api:$jspApiVersion") { provided = true }
-        testCompile "org.springframework.social:spring-social-test:$springSocialVersion"
+        compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+        compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     }
 }
 
@@ -149,7 +147,16 @@ project('spring-social-instagram') {
 // Configuration for the docs subproject
 // -----------------------------------------------------------------------------
 project('docs') {
-    apply from: "$buildSrcDir/docs.gradle"
+    apply plugin: 'base'
+    task api(type: Javadoc) {
+        source javaprojects.collect { project ->
+            project.sourceSets.main.allJava
+        }
+        classpath = files(javaprojects.collect { project ->
+            project.sourceSets.main.compileClasspath
+        })
+        destinationDir = file("build/api")
+    }
 }
 
 apply from: "$buildSrcDir/dist.gradle"

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Aspect.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Aspect.java
@@ -1,0 +1,7 @@
+package org.springframework.social.instagram.api;
+
+public enum Aspect {
+
+    media
+    
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Caption.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Caption.java
@@ -4,19 +4,19 @@ import java.util.Date;
 
 public class Caption {
 	
-	private long id;
+	private String id;
 	private Date createdTime;
 	private String text;
 	private InstagramProfile from;
 	
-	public Caption(long id, Date createdTime, String text, InstagramProfile from) {
+	public Caption(String id, Date createdTime, String text, InstagramProfile from) {
 		this.id = id;
 		this.createdTime = createdTime;
 		this.text = text;
 		this.from = from;
 	}
 
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Comment.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Comment.java
@@ -4,19 +4,19 @@ import java.util.Date;
 
 public class Comment {
 	
-	private long id;
+	private String id;
 	private Date createdTime;
 	private String text;
 	private InstagramProfile from;
 	
-	public Comment(long id, Date createdTime, String text, InstagramProfile from) {
+	public Comment(String id, Date createdTime, String text, InstagramProfile from) {
 		this.id = id;
 		this.createdTime = createdTime;
 		this.text = text;
 		this.from = from;
 	}
 	
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Instagram.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Instagram.java
@@ -1,12 +1,16 @@
 package org.springframework.social.instagram.api;
 
+import org.springframework.social.ApiBinding;
+
 /**
  * Interface specifying a basic set of operations for interacting with Instagram.
  * Implemented by InstagramTemplate. Not often used directly, but a useful option
  * to enhance testability, as it can easily be mocked or stubbed.
  */
-public interface Instagram {
+public interface Instagram extends ApiBinding {
 	
+    public static final String PROVIDER_ID = "instagram";
+    
 	/**
 	 * Returns the portion of the Instagram API that handles tag operations
 	 */
@@ -21,6 +25,12 @@ public interface Instagram {
 	 * Returns the portion of the Instagram API that handles media operations
 	 */
 	MediaOperations mediaOperations();
+	
+	/**
+	 * Returns the portion of the Instagram API that handles subscription operations
+	 * @return
+	 */
+	SubscriptionOperations subscriptionOperations();
 	
 	/**
 	 * Returns the portion of the Instagram API that handles user operations

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/InstagramProfile.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/InstagramProfile.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public class InstagramProfile {
 	
-	private final long id;
+	private final String id;
 	private final String profilePictureUrl;
 	private final String username;
 	private final Map<String,Integer> counts;
@@ -14,7 +14,7 @@ public class InstagramProfile {
 	private String firstName;
 	private String lastName;
 	
-	public InstagramProfile(long id, String username, String fullName, String profilePictureUrl, Map<String,Integer> counts) {
+	public InstagramProfile(String id, String username, String fullName, String profilePictureUrl, Map<String,Integer> counts) {
 		this.id = id;
 		this.username = username;
 		this.fullName = fullName;
@@ -22,7 +22,7 @@ public class InstagramProfile {
 		this.counts = counts;
 	}
 	
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 	

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Location.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Location.java
@@ -2,19 +2,19 @@ package org.springframework.social.instagram.api;
 
 public class Location {
 	
-	private long id;
+	private String id;
 	private String name;
 	private double latitude;
 	private double longitude;
 	
-	public Location(long id, String name, double latitude, double longitude) {
+	public Location(String id, String name, double latitude, double longitude) {
 		this.id = id;
 		this.name = name;
 		this.latitude = latitude;
 		this.longitude = longitude;
 	}
 
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/LocationOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/LocationOperations.java
@@ -10,14 +10,14 @@ public interface LocationOperations {
 	 * @param locationId	Location ID
 	 * @return	Location information
 	 */
-	Location getLocation(long locationId);
+	Location getLocation(String locationId);
 	
 	/**
 	 * Get recent media based on location
 	 * @param locationId	Location ID
 	 * @return	A list of media
 	 */
-	PagedMediaList getRecentMedia(long locationId);
+	PagedMediaList getRecentMedia(String locationId);
 	
 	/**
 	 * Get recent media based on location
@@ -28,7 +28,7 @@ public interface LocationOperations {
 	 * @param maxTimeStamp	Will return media before this UNIX time stamp
 	 * @return	A list of media
 	 */
-	PagedMediaList getRecentMedia(long locationId, long maxId, long minId, long minTimeStamp, long maxTimeStamp);
+	PagedMediaList getRecentMedia(String locationId, String maxId, String minId, long minTimeStamp, long maxTimeStamp);
 	
 	/**
 	 * Search for a location by geographic coordinate using default distance of 1000 meters.

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Media.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Media.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public class Media {
 	
-	private long id;
+	private String id;
 	private String filter;
 	private String link;
 	private Caption caption;
@@ -15,14 +15,16 @@ public class Media {
     private Date createdTime;
     private boolean userHasLiked;
     private Map<String,Image> images;
+    private Map<String,Video> videos;
     private List<String> tags;
     private LikesInfo likes;
 	private CommentsInfo comments;
 	
-	public Media(long id, String filter, String link,
+	public Media(String id, String filter, String link,
 			 Caption caption, InstagramProfile user, Location location,
-			 Date createdTime, boolean userHasLiked, Map<String,Image> images,
-			 List<String> tags, LikesInfo likes, CommentsInfo comments) {
+			 Date createdTime, boolean userHasLiked, Map<String,Image> images, 
+			 Map<String,Video> videos, List<String> tags, LikesInfo likes, 
+			 CommentsInfo comments) {
 		
 		this.id = id;
 		this.filter = filter;
@@ -38,7 +40,7 @@ public class Media {
         this.comments = comments;
 	}
 	
-	public long getId() {
+	public String getId() {
 		return id;
 	}
 
@@ -72,6 +74,10 @@ public class Media {
     
     public Map<String,Image> getImages() {
         return images;
+    }
+    
+    public Map<String, Video> getVideos() {
+        return videos;
     }
     
     public List<String> getTags() {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/MediaOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/MediaOperations.java
@@ -10,47 +10,47 @@ public interface MediaOperations {
 	 * @param mediaId
 	 * @param text
 	 */
-	void addComment(long mediaId, String text);
+	void addComment(String mediaId, String text);
 	
 	/**
 	 * Set a like on this media by the currently authenticated user.
 	 * @param mediaId
 	 */
-	void addLike(long mediaId);
+	void addLike(String mediaId);
 	
 	/**
 	 * Remove a comment either on the authenticated user's media or authored by the authenticated user.
 	 * @param mediaId
 	 * @param commentId
 	 */
-	void deleteComment(long mediaId, long commentId);
+	void deleteComment(String mediaId, String commentId);
 	
 	/**
 	 * Remove a like on this media by the currently authenticated user.
 	 * @param mediaId
 	 */
-	void deleteLike(long mediaId);
+	void deleteLike(String mediaId);
 	
 	/**
 	 * Get a full list of comments on a media.
 	 * @param mediaId
 	 * @return A list of comments
 	 */
-	List<Comment> getComments(long mediaId);
+	List<Comment> getComments(String mediaId);
 	
 	/**
 	 * Get a list of users who have liked this media.
 	 * @param mediaId
 	 * @return A list of users
 	 */
-	List<InstagramProfile> getLikes(long mediaId);
+	List<InstagramProfile> getLikes(String mediaId);
 	
 	/**
 	 * Get information about a media object.
 	 * @param mediaId
 	 * @return Media information
 	 */
-	Media getMedia(long mediaId);
+	Media getMedia(String mediaId);
 	
 	/**
 	 * Get a list of what media is most popular at the moment.

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Pagination.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Pagination.java
@@ -3,10 +3,10 @@ package org.springframework.social.instagram.api;
 public class Pagination {
 	
 	private String nextUrl;
-	private long nextMaxId;
-	private long nextMinId;
+	private String nextMaxId;
+	private String nextMinId;
 	
-	public Pagination(String nextUrl, long nextMaxId, long nextMinId) {
+	public Pagination(String nextUrl, String nextMaxId, String nextMinId) {
 		this.nextUrl = nextUrl;
 		this.nextMaxId = nextMaxId;
 		this.nextMinId = nextMinId;
@@ -16,11 +16,11 @@ public class Pagination {
 		return nextUrl;
 	}
 
-	public long getNextMaxId() {
+	public String getNextMaxId() {
 		return nextMaxId;
 	}
 
-	public long getNextMinId() {
+	public String getNextMinId() {
 		return nextMinId;
 	}
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Subscription.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Subscription.java
@@ -1,0 +1,47 @@
+package org.springframework.social.instagram.api;
+
+import java.net.URI;
+
+public class Subscription {
+
+    private String id;
+    private String type;
+    private SubscriptionObject object;
+    private String objectId;
+    private Aspect aspect;
+    private URI callbackUrl;
+
+    public Subscription(String id, String type, SubscriptionObject object, String objectId, Aspect aspect, URI callbackUrl) {
+        this.id = id;
+        this.type = type;
+        this.object = object;
+        this.objectId = objectId;
+        this.aspect = aspect;
+        this.callbackUrl = callbackUrl;
+    }
+    
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public SubscriptionObject getObject() {
+        return object;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public Aspect getAspect() {
+        return aspect;
+    }
+
+    public URI getCallbackUrl() {
+        return callbackUrl;
+    }
+
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/SubscriptionObject.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/SubscriptionObject.java
@@ -1,0 +1,7 @@
+package org.springframework.social.instagram.api;
+
+public enum SubscriptionObject {
+
+    user, tag, location, geography
+    
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/SubscriptionOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/SubscriptionOperations.java
@@ -1,0 +1,27 @@
+package org.springframework.social.instagram.api;
+
+import java.net.URI;
+import java.util.List;
+
+public interface SubscriptionOperations {
+
+    List<Subscription> createGeographySubscription(Aspect aspect, String verifyToken, URI callbackUri, double lat,
+                                                   double lng, int radius);
+
+    List<Subscription> createLocationSubscription(Aspect aspect, String verifyToken, URI callbackUri, String objectId);
+
+    List<Subscription> createTagSubscription(Aspect aspect, String verifyToken, URI callbackUri, String objectId);
+
+    List<Subscription> createUserSubscription(Aspect aspect, String verifyToken, URI callbackUri);
+
+    List<Subscription> getSubscriptions();
+
+    void deleteSubscription(String id);
+
+    void deleteSubscriptions(SubscriptionObject object);
+
+    void deleteAllSubscriptions();
+
+    public static final String SUBSCRIPTIONS_ENDPOINT = "subscriptions/";
+
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/TagOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/TagOperations.java
@@ -26,7 +26,7 @@ public interface TagOperations {
 	 * @param minId		Will return media before this ID
 	 * @return	A list of media
 	 */
-	PagedMediaList getRecentMedia(String tagName, long maxId, long minId);
+	PagedMediaList getRecentMedia(String tagName, String maxId, String minId);
 
 	/**
 	 * Search for tags by name - results are ordered first as an exact match, then by popularity.

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Update.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Update.java
@@ -1,0 +1,43 @@
+package org.springframework.social.instagram.api;
+
+import java.io.Serializable;
+
+public class Update implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String subscriptionId;
+    private SubscriptionObject object;
+    private String objectId;
+    private Aspect changedAspect;
+    private long time;
+
+    public Update(String subscriptionId, SubscriptionObject object, String objectId, Aspect changedAspect, long time) {
+        this.subscriptionId = subscriptionId;
+        this.object = object;
+        this.objectId = objectId;
+        this.changedAspect = changedAspect;
+        this.time = time;
+    }
+
+    public String getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    public SubscriptionObject getObject() {
+        return object;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public Aspect getChangedAspect() {
+        return changedAspect;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/UserOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/UserOperations.java
@@ -20,7 +20,7 @@ public interface UserOperations {
 	 * @param userId
 	 * @return	Instagram profile
 	 */
-	InstagramProfile getUser(long userId);
+	InstagramProfile getUser(String userId);
 	
 	/**
 	 * Get the first page of the authenticated user's feed
@@ -34,14 +34,14 @@ public interface UserOperations {
      * @param minId Get media after this ID
      * @return List of media
      */
-	PagedMediaList getFeed(long maxId, long minId);
+	PagedMediaList getFeed(String maxId, String minId);
 	
 	/**
 	 * Get recent media of a specific user
 	 * @param userId
 	 * @return	List of media
 	 */
-	 PagedMediaList getRecentMedia(long userId);
+	 PagedMediaList getRecentMedia(String userId);
 	
 	/**
      * Get a range of recent media of a specific user
@@ -52,7 +52,7 @@ public interface UserOperations {
      * @param manTimestamp Get media before this Unix timestamp
      * @return  List of media
      */
-	 PagedMediaList getRecentMedia(long userId, long maxId, long minId, long minTimestamp, long maxTimestamp);
+	 PagedMediaList getRecentMedia(String userId, String maxId, String minId, long minTimestamp, long maxTimestamp);
 	
 	/**
 	 * Search for users
@@ -66,14 +66,14 @@ public interface UserOperations {
 	 * @param userId
 	 * @return	List of profiles
 	 */
-	List<InstagramProfile> getFollows(long userId);
+	List<InstagramProfile> getFollows(String userId);
 	
 	/**
 	 * Get the list of users the specified user is followed by
 	 * @param userId
 	 * @return	List of profiles
 	 */
-	List<InstagramProfile> getFollowedBy(long userId);
+	List<InstagramProfile> getFollowedBy(String userId);
 	
 	/**
 	 * List the users who have requested the authenticated user's permission to follow
@@ -86,43 +86,43 @@ public interface UserOperations {
 	 * @param userId
 	 * @return User relationship
 	 */
-	Relationship getRelationship(long userId);
+	Relationship getRelationship(String userId);
 	
 	/**
 	 * Send a request to follow the specified user
 	 * @param userId
 	 */
-	void followUser(long userId);
+	void followUser(String userId);
 	
 	/**
 	 * Stop following the specified user
 	 * @param userId
 	 */
-	void unfollowUser(long userId);
+	void unfollowUser(String userId);
 	
 	/**
 	 * Block the specified user
 	 * @param userId
 	 */
-	void blockUser(long userId);
+	void blockUser(String userId);
 	
 	/**
 	 * Unblock the specified user
 	 * @param userId
 	 */
-	void unblockUser(long userId);
+	void unblockUser(String userId);
 	
 	/**
 	 * Approve a user's request to follow the authenticated user
 	 * @param userId
 	 */
-	void approveUser(long userId);
+	void approveUser(String userId);
 	
 	/**
 	 * Deny a user's request to follow the authenticated user
 	 * @param user
 	 */
-	void denyUser(long user);
+	void denyUser(String user);
 	
 	public static final String USERS_ENDPOINT = "users/";
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Video.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/Video.java
@@ -1,0 +1,29 @@
+package org.springframework.social.instagram.api;
+
+public class Video {
+
+	public static final String LOW_RESOLUTION = "low_resolution";
+	public static final String STANDARD_RESOLUTION = "standard_resolution";
+	
+	private String url;
+	private int width;
+	private int height;
+	
+	public Video(String url, int width, int height) {
+		this.url = url;
+		this.width = width;
+		this.height = height;
+	}
+	
+	public String getUrl() {
+		return url;
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/AbstractInstagramDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/AbstractInstagramDeserializer.java
@@ -1,11 +1,11 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.JsonToken;
-import org.codehaus.jackson.map.JsonDeserializer;
+import java.io.IOException;
 
 abstract class AbstractInstagramDeserializer<T> extends JsonDeserializer<T> {
     

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/AbstractInstagramOperations.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/AbstractInstagramOperations.java
@@ -1,13 +1,14 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.Map;
-
 import org.springframework.social.MissingAuthorizationException;
+import org.springframework.social.instagram.api.Instagram;
 import org.springframework.social.support.URIBuilder;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
 
 public abstract class AbstractInstagramOperations {
 	
@@ -35,7 +36,7 @@ public abstract class AbstractInstagramOperations {
 	
 	protected void requireUserAuthorization() {
 		if(!isAuthorized) {
-			throw new MissingAuthorizationException();
+			throw new MissingAuthorizationException(Instagram.PROVIDER_ID);
 		}
 	}
 	

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CaptionMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CaptionMixin.java
@@ -1,18 +1,19 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class CaptionMixin {
     @JsonCreator
     CaptionMixin(
-            @JsonProperty("id") long id,
+            @JsonProperty("id") String id,
             @JsonProperty("created_time") @JsonDeserialize(using=InstagramDateDeserializer.class) Date createdTime,
             @JsonProperty("text") String text,
             @JsonProperty("from") InstagramProfile from) {}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CommentList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CommentList.java
@@ -1,10 +1,11 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.Comment;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CommentList {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CommentMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/CommentMixin.java
@@ -1,18 +1,19 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class CommentMixin {
     @JsonCreator
     CommentMixin(
-            @JsonProperty("id") long id,
+            @JsonProperty("id") String id,
             @JsonProperty("created_time") @JsonDeserialize(using=InstagramDateDeserializer.class) Date createdTime,
             @JsonProperty("text") String text,
             @JsonProperty("from") InstagramProfile from) {}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/ImageMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/ImageMixin.java
@@ -1,8 +1,8 @@
 package org.springframework.social.instagram.api.impl;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class ImageMixin {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramDateDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramDateDeserializer.java
@@ -1,12 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
 import java.io.IOException;
 import java.util.Date;
-
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
 
 public class InstagramDateDeserializer extends JsonDeserializer<Date> {
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramErrorHandler.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramErrorHandler.java
@@ -1,14 +1,15 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
-import java.util.Map;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.social.instagram.api.InstagramApiException;
 import org.springframework.web.client.DefaultResponseErrorHandler;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class InstagramErrorHandler extends DefaultResponseErrorHandler {
 	

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramModule.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramModule.java
@@ -1,7 +1,7 @@
 package org.springframework.social.instagram.api.impl;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import org.springframework.social.instagram.api.Caption;
 import org.springframework.social.instagram.api.Comment;
 import org.springframework.social.instagram.api.CommentsInfo;
@@ -14,11 +14,14 @@ import org.springframework.social.instagram.api.PagedMediaList;
 import org.springframework.social.instagram.api.Pagination;
 import org.springframework.social.instagram.api.Relationship;
 import org.springframework.social.instagram.api.Tag;
+import org.springframework.social.instagram.api.Video;
 
 public class InstagramModule extends SimpleModule {
 
+    private static final long serialVersionUID = 1L;
+
     public InstagramModule() {
-        super(InstagramModule.class.getName(), new Version(1, 0, 0, null));
+        super(InstagramModule.class.getName());
     }
 
     @Override public void setupModule(SetupContext context) {
@@ -34,6 +37,7 @@ public class InstagramModule extends SimpleModule {
         context.setMixInAnnotations(Pagination.class, PaginationMixin.class);
         context.setMixInAnnotations(Relationship.class, RelationshipMixin.class);
         context.setMixInAnnotations(Tag.class, TagMixin.class);
+        context.setMixInAnnotations(Video.class, VideoMixin.class);
     }
 
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileContainer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileContainer.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.io.IOException;
 
 @JsonDeserialize(using=InstagramProfileContainer.InstagramProfileContainerDeserializer.class)
 public class InstagramProfileContainer extends AbstractInstagramResponseContainer<InstagramProfile>{

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileContainerDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileContainerDeserializer.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.io.IOException;
 
 public class InstagramProfileContainerDeserializer extends AbstractInstagramDeserializer<InstagramProfileContainer> {
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileList.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class InstagramProfileList {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramProfileMixin.java
@@ -1,10 +1,10 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import java.util.Map;
 
 /**
  * Mixin class for adding Jackson annotations to InstagramProfile.
@@ -13,7 +13,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
 abstract class InstagramProfileMixin {
     @JsonCreator
     InstagramProfileMixin(
-            @JsonProperty("id") long id, 
+            @JsonProperty("id") String id, 
             @JsonProperty("username") String username, 
             @JsonProperty("full_name") String fullName, 
             @JsonProperty("profile_picture") String profilePictureUrl, 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/InstagramTemplate.java
@@ -1,20 +1,23 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Arrays;
-import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter;
 import org.springframework.social.instagram.api.Instagram;
 import org.springframework.social.instagram.api.LocationOperations;
 import org.springframework.social.instagram.api.MediaOperations;
+import org.springframework.social.instagram.api.SubscriptionOperations;
 import org.springframework.social.instagram.api.TagOperations;
 import org.springframework.social.instagram.api.UserOperations;
 import org.springframework.social.oauth2.AbstractOAuth2ApiBinding;
 import org.springframework.social.support.URIBuilder;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * This is the central class for interacting with Instagram.
@@ -37,6 +40,7 @@ public class InstagramTemplate extends AbstractOAuth2ApiBinding implements Insta
 	private final TagOperations tagOperations;
 	private final LocationOperations locationOperations;
 	private final MediaOperations mediaOperations;
+	private final SubscriptionOperations subscriptionOperations;
 	private final UserOperations userOperations;
 	
 	/**
@@ -63,7 +67,7 @@ public class InstagramTemplate extends AbstractOAuth2ApiBinding implements Insta
 	    super(accessToken);
 		this.clientId = clientId;
 		this.accessToken = accessToken;	
-		MappingJacksonHttpMessageConverter json = new MappingJacksonHttpMessageConverter();
+		MappingJackson2HttpMessageConverter json = new MappingJackson2HttpMessageConverter();
         json.setSupportedMediaTypes(Arrays.asList(new MediaType("text", "javascript")));
 		getRestTemplate().getMessageConverters().add(json);
 		registerInstagramJsonModule(getRestTemplate());
@@ -72,14 +76,15 @@ public class InstagramTemplate extends AbstractOAuth2ApiBinding implements Insta
 		tagOperations = new TagTemplate(this, isAuthorizedForUser);
 		locationOperations = new LocationTemplate(this, isAuthorizedForUser);
 		mediaOperations = new MediaTemplate(this, isAuthorizedForUser);
+		subscriptionOperations = new SubscriptionTemplate(this, isAuthorizedForUser);
 		userOperations = new UserTemplate(this, isAuthorizedForUser);
 	}
 	
 	private void registerInstagramJsonModule(RestTemplate restTemplate) {
 	    List<HttpMessageConverter<?>> converters = restTemplate.getMessageConverters();
         for (HttpMessageConverter<?> converter : converters) {
-            if(converter instanceof MappingJacksonHttpMessageConverter) {
-                MappingJacksonHttpMessageConverter jsonConverter = (MappingJacksonHttpMessageConverter) converter;
+            if(converter instanceof MappingJackson2HttpMessageConverter) {
+                MappingJackson2HttpMessageConverter jsonConverter = (MappingJackson2HttpMessageConverter) converter;
                 ObjectMapper objectMapper = new ObjectMapper();             
                 objectMapper.registerModule(new InstagramModule());
                 jsonConverter.setObjectMapper(objectMapper);
@@ -103,6 +108,10 @@ public class InstagramTemplate extends AbstractOAuth2ApiBinding implements Insta
 	
 	public MediaOperations mediaOperations() {
 		return mediaOperations;
+	}
+	
+	public SubscriptionOperations subscriptionOperations() {
+	    return subscriptionOperations;
 	}
 	
 	public UserOperations userOperations() {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LikesInfoMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LikesInfoMixin.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.InstagramProfile;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class LikesInfoMixin {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationContainer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationContainer.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Location;
+
+import java.io.IOException;
 
 @JsonDeserialize(using=LocationContainer.LocationContainerDeseriazlier.class)
 public class LocationContainer extends AbstractInstagramResponseContainer<Location> {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationList.java
@@ -1,10 +1,11 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.Location;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class LocationList {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationMixin.java
@@ -1,14 +1,14 @@
 package org.springframework.social.instagram.api.impl;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class LocationMixin {
     @JsonCreator
     LocationMixin(
-            @JsonProperty("id") long id,
+            @JsonProperty("id") String id,
             @JsonProperty("name") String name,
             @JsonProperty("latitude") double latitude,
             @JsonProperty("longitude") double longitude) {}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/LocationTemplate.java
@@ -1,13 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
+import org.springframework.social.instagram.api.Location;
+import org.springframework.social.instagram.api.LocationOperations;
+import org.springframework.social.instagram.api.PagedMediaList;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.social.instagram.api.Location;
-import org.springframework.social.instagram.api.LocationOperations;
-import org.springframework.social.instagram.api.PagedMediaList;
 
 /**
  * Implementation of {@link LocationOperations}, providing a binding to Instagram's location-oriented REST resources.
@@ -18,21 +18,21 @@ public class LocationTemplate extends AbstractInstagramOperations implements Loc
 		super(instagram, isAuthorizedForUser);
 	}
 	
-	public Location getLocation(long locationId) {
-		return get(buildUri(LOCATIONS_ENDPOINT + Long.toString(locationId) +"/"), LocationContainer.class).getObject();
+	public Location getLocation(String locationId) {
+		return get(buildUri(LOCATIONS_ENDPOINT + locationId +"/"), LocationContainer.class).getObject();
 	}
 
-	public PagedMediaList getRecentMedia(long locationId) {
-		return getRecentMedia(locationId, 0, 0, 0, 0);
+	public PagedMediaList getRecentMedia(String locationId) {
+		return getRecentMedia(locationId, null, null, 0, 0);
 	}
 	
-	public PagedMediaList getRecentMedia(long locationId, long maxId, long minId, long minTimeStamp, long maxTimeStamp) {
+	public PagedMediaList getRecentMedia(String locationId, String maxId, String minId, long minTimeStamp, long maxTimeStamp) {
 		Map<String,String> params = new HashMap<String,String>();
-		if(maxId > 0) params.put("max_id", Long.toString(maxId));
-		if(minId > 0) params.put("min_id", Long.toString(minId));
+		if(maxId != null) params.put("max_id", maxId);
+		if(minId != null) params.put("min_id", minId);
 		if(minTimeStamp > 0) params.put("min_timestamp", Long.toString(minTimeStamp));
 		if(maxTimeStamp > 0) params.put("max_timestamp", Long.toString(maxTimeStamp));
-		return get(buildUri(LOCATIONS_ENDPOINT + Long.toString(locationId) + "/media/recent/", params), PagedMediaList.class);
+		return get(buildUri(LOCATIONS_ENDPOINT + locationId + "/media/recent/", params), PagedMediaList.class);
 	}
 
 	public List<Location> search(double latitude, double longitude) {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaContainer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaContainer.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Media;
+
+import java.io.IOException;
 
 @JsonDeserialize(using=MediaContainer.MediaContainerDeserializer.class)
 public class MediaContainer extends AbstractInstagramResponseContainer<Media> {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaContainerDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaContainerDeserializer.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
 import org.springframework.social.instagram.api.Media;
+
+import java.io.IOException;
 
 public class MediaContainerDeserializer extends AbstractInstagramDeserializer<MediaContainer> {
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaList.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.Media;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class MediaList {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaMixin.java
@@ -1,25 +1,27 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Caption;
 import org.springframework.social.instagram.api.CommentsInfo;
 import org.springframework.social.instagram.api.Image;
 import org.springframework.social.instagram.api.InstagramProfile;
 import org.springframework.social.instagram.api.LikesInfo;
 import org.springframework.social.instagram.api.Location;
+import org.springframework.social.instagram.api.Video;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class MediaMixin {
     @JsonCreator
     public MediaMixin(
-            @JsonProperty("id") long id,
+            @JsonProperty("id") String id,
             @JsonProperty("filter") String filter,
             @JsonProperty("link") String link,
             @JsonProperty("caption") Caption caption,
@@ -28,6 +30,7 @@ abstract class MediaMixin {
             @JsonProperty("created_time") @JsonDeserialize(using=InstagramDateDeserializer.class) Date createdTime,
             @JsonProperty("user_has_liked") boolean userHasLiked,
             @JsonProperty("images") Map<String,Image> images,
+            @JsonProperty("videos") Map<String,Video> videos,
             @JsonProperty("tags") List<String> tags,
             @JsonProperty("likes") LikesInfo likes,
             @JsonProperty("comments") CommentsInfo comments) {}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/MediaTemplate.java
@@ -1,15 +1,15 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.springframework.social.instagram.api.Comment;
 import org.springframework.social.instagram.api.InstagramProfile;
 import org.springframework.social.instagram.api.Media;
 import org.springframework.social.instagram.api.MediaOperations;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link MediaOperations}, providing a binding to Instagram's media-oriented REST resources.
@@ -21,38 +21,38 @@ public class MediaTemplate extends AbstractInstagramOperations implements MediaO
 		super(instagram, isAuthorizedForUser);
 	}
 	
-	public void addComment(long mediaId, String text) {
+	public void addComment(String mediaId, String text) {
 		requireUserAuthorization();
 		MultiValueMap<String,String> params = new LinkedMultiValueMap<String, String>();
         params.add("text", text);
-		post(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/comments/"), params, Map.class);
+		post(buildUri(MEDIA_ENDPOINT + mediaId + "/comments/"), params, Map.class);
 	}
 
-	public void addLike(long mediaId) {
+	public void addLike(String mediaId) {
 		requireUserAuthorization();
-		post(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/likes/"), new LinkedMultiValueMap<String, String>(), Map.class);
+		post(buildUri(MEDIA_ENDPOINT + mediaId + "/likes/"), new LinkedMultiValueMap<String, String>(), Map.class);
 	}
 
-	public void deleteComment(long mediaId, long commentId) {
+	public void deleteComment(String mediaId, String commentId) {
 		requireUserAuthorization();
-		delete(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/comments/" + Long.toString(commentId) + "/"));
+		delete(buildUri(MEDIA_ENDPOINT + mediaId + "/comments/" + commentId + "/"));
 	}
 
-	public void deleteLike(long mediaId) {
+	public void deleteLike(String mediaId) {
 		requireUserAuthorization();
-		delete(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/likes/"));
+		delete(buildUri(MEDIA_ENDPOINT + mediaId + "/likes/"));
 	}
 
-	public List<Comment> getComments(long mediaId) {
-		return get(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/comments/"), CommentList.class).getList();
+	public List<Comment> getComments(String mediaId) {
+		return get(buildUri(MEDIA_ENDPOINT + mediaId + "/comments/"), CommentList.class).getList();
 	}
 
-	public List<InstagramProfile> getLikes(long mediaId) {
-		return get(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId) + "/likes/"), InstagramProfileList.class).getList();
+	public List<InstagramProfile> getLikes(String mediaId) {
+		return get(buildUri(MEDIA_ENDPOINT + mediaId + "/likes/"), InstagramProfileList.class).getList();
 	}
 
-	public Media getMedia(long mediaId) {
-		return get(buildUri(MEDIA_ENDPOINT + Long.toString(mediaId)+ "/"), MediaContainer.class).getObject();
+	public Media getMedia(String mediaId) {
+		return get(buildUri(MEDIA_ENDPOINT + mediaId+ "/"), MediaContainer.class).getObject();
 	}
 
 	public List<Media> getPopular() {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/PagedMediaListMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/PagedMediaListMixin.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.Media;
 import org.springframework.social.instagram.api.Pagination;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class PagedMediaListMixin {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/PaginationMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/PaginationMixin.java
@@ -1,14 +1,14 @@
 package org.springframework.social.instagram.api.impl;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 abstract class PaginationMixin {
 	@JsonCreator
 	PaginationMixin(
 			@JsonProperty("next_url") String nextUrl,
-			@JsonProperty("next_max_id") long nextMaxId,
-			@JsonProperty("next_min_id") long nextMinId) {}
+			@JsonProperty("next_max_id") String nextMaxId,
+			@JsonProperty("next_min_id") String nextMinId) {}
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipContainer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipContainer.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Relationship;
+
+import java.io.IOException;
 
 @JsonDeserialize(using=RelationshipContainer.RelationshipContainerDeserializer.class)
 public class RelationshipContainer extends AbstractInstagramResponseContainer<Relationship> {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipContainerDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipContainerDeserializer.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
 import org.springframework.social.instagram.api.Relationship;
+
+import java.io.IOException;
 
 public class RelationshipContainerDeserializer extends AbstractInstagramDeserializer<RelationshipContainer> {
     

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/RelationshipMixin.java
@@ -1,17 +1,18 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.JsonDeserializer;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Relationship.IncomingStatus;
 import org.springframework.social.instagram.api.Relationship.OutgoingStatus;
+
+import java.io.IOException;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class RelationshipMixin {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionMixin.java
@@ -1,0 +1,25 @@
+package org.springframework.social.instagram.api.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.social.instagram.api.Aspect;
+import org.springframework.social.instagram.api.SubscriptionObject;
+
+import java.net.URI;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+abstract class SubscriptionMixin {
+    @JsonCreator
+    public SubscriptionMixin(
+            @JsonProperty("id") String id,
+            @JsonProperty("type") String type,
+            @JsonProperty("object") SubscriptionObject object,
+            @JsonProperty("object_id") String objectId,
+            @JsonProperty("aspect") Aspect aspect,
+            @JsonProperty("callback_url") URI callbackUrl) {}
+    
+}
+
+

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionTemplate.java
@@ -1,0 +1,89 @@
+package org.springframework.social.instagram.api.impl;
+
+import org.springframework.social.instagram.api.Aspect;
+import org.springframework.social.instagram.api.Subscription;
+import org.springframework.social.instagram.api.SubscriptionObject;
+import org.springframework.social.instagram.api.SubscriptionOperations;
+import org.springframework.social.support.URIBuilder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.net.URI;
+import java.util.List;
+
+public class SubscriptionTemplate extends AbstractInstagramOperations implements SubscriptionOperations {
+
+    private static final String SUBSCRIPTIONS = "subscriptions";
+    private static final String OBJECT_ID = "object_id";
+    private static final String OBJECT = "object";
+
+    public SubscriptionTemplate(InstagramTemplate instagramTemplate, boolean isAuthorizedForUser) {
+        super(instagramTemplate, isAuthorizedForUser);
+    }
+
+    public List<Subscription> createGeographySubscription(Aspect aspect, String verifyToken, URI callbackUri,
+                                                          double lat, double lng, int radius) {
+        final MultiValueMap<String, String> data = new LinkedMultiValueMap<String, String>();
+        data.add(OBJECT, SubscriptionObject.tag.name());
+        data.add("lat", Double.toString(lat));
+        data.add("lng", Double.toString(lat));
+        data.add("radius", Integer.toString(radius));
+        data.add("aspect", aspect.name());
+        data.add("verify_token", verifyToken);
+        data.add("callback_url", callbackUri.toString());
+        return post(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS), data, SubscriptionsList.class).getList();
+    }
+
+    public List<Subscription> createLocationSubscription(Aspect aspect, String verifyToken, URI callbackUri,
+                                                         String objectId) {
+        final MultiValueMap<String, String> data = new LinkedMultiValueMap<String, String>();
+        data.add(OBJECT, SubscriptionObject.location.name());
+        data.add(OBJECT_ID, objectId);
+        data.add("aspect", aspect.name());
+        data.add("verify_token", verifyToken);
+        data.add("callback_url", callbackUri.toString());
+        return post(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS), data, SubscriptionsList.class).getList();
+    }
+
+    public List<Subscription> createTagSubscription(Aspect aspect, String verifyToken, URI callbackUri, String objectId) {
+        final MultiValueMap<String, String> data = new LinkedMultiValueMap<String, String>();
+        data.add(OBJECT, SubscriptionObject.tag.name());
+        data.add(OBJECT_ID, objectId);
+        data.add("aspect", aspect.name());
+        data.add("verify_token", verifyToken);
+        data.add("callback_url", callbackUri.toString());
+        return post(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS), data, SubscriptionsList.class).getList();
+    }
+
+    public List<Subscription> createUserSubscription(Aspect aspect, String verifyToken, URI callbackUri) {
+        final MultiValueMap<String, String> data = new LinkedMultiValueMap<String, String>();
+        data.add(OBJECT, SubscriptionObject.user.name());
+        data.add("aspect", aspect.name());
+        data.add("verify_token", verifyToken);
+        data.add("callback_url", callbackUri.toString());
+        return post(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS), data, SubscriptionsList.class).getList();
+    }
+
+    public List<Subscription> getSubscriptions() {
+        return get(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS), SubscriptionsList.class).getList();
+    }
+
+    public void deleteSubscription(String id) {
+        final URI uri = URIBuilder.fromUri(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS).toString())
+                .queryParam("id", id).build();
+        delete(uri);
+    }
+
+    public void deleteSubscriptions(SubscriptionObject object) {
+        final URI uri = URIBuilder.fromUri(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS).toString())
+                .queryParam(OBJECT, object.name()).build();
+        delete(uri);
+    }
+
+    public void deleteAllSubscriptions() {
+        final URI uri = URIBuilder.fromUri(buildUri(SUBSCRIPTIONS_ENDPOINT + SUBSCRIPTIONS).toString())
+                .queryParam(OBJECT, "all").build();
+        delete(uri);
+    }
+
+}

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionsList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/SubscriptionsList.java
@@ -4,16 +4,21 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.springframework.social.instagram.api.Comment;
+import org.springframework.social.instagram.api.Subscription;
 
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
-abstract class CommentsInfoMixin {
-    @JsonCreator
-    CommentsInfoMixin(
-            @JsonProperty("count") int total,
-            @JsonProperty("data") List<Comment> list) {}
-    
+public class SubscriptionsList {
 
+    private List<Subscription> list;
+    
+    @JsonCreator
+    public SubscriptionsList(@JsonProperty("data") List<Subscription> list) {
+        this.list = list;
+    }
+    
+    public List<Subscription> getList() {
+        return list;
+    }
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagContainer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagContainer.java
@@ -1,12 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
-import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.springframework.social.instagram.api.Tag;
+
+import java.io.IOException;
 
 @JsonDeserialize(using=TagContainer.TagContainerDeserializer.class)
 public class TagContainer extends AbstractInstagramResponseContainer<Tag> {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagContainerDeserializer.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagContainerDeserializer.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
 
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonProcessingException;
-import org.codehaus.jackson.map.DeserializationContext;
 import org.springframework.social.instagram.api.Tag;
+
+import java.io.IOException;
 
 public class TagContainerDeserializer extends AbstractInstagramDeserializer<TagContainer> {
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagList.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagList.java
@@ -1,11 +1,12 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
 import org.springframework.social.instagram.api.Tag;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class TagList {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagMixin.java
@@ -1,8 +1,8 @@
 package org.springframework.social.instagram.api.impl;
 
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonIgnoreProperties;
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class TagMixin {

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/TagTemplate.java
@@ -1,13 +1,13 @@
 package org.springframework.social.instagram.api.impl;
 
+import org.springframework.social.instagram.api.PagedMediaList;
+import org.springframework.social.instagram.api.Tag;
+import org.springframework.social.instagram.api.TagOperations;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.springframework.social.instagram.api.PagedMediaList;
-import org.springframework.social.instagram.api.Tag;
-import org.springframework.social.instagram.api.TagOperations;
 
 /**
  * Implementation of {@link TagOperations}, providing a binding to Instagram's tag-oriented REST resources.
@@ -23,13 +23,13 @@ public class TagTemplate extends AbstractInstagramOperations implements TagOpera
 	}
 
 	public PagedMediaList getRecentMedia(String tagName) {
-		return getRecentMedia(tagName, 0, 0);
+		return getRecentMedia(tagName, null, null);
 	}
 	
-	public PagedMediaList getRecentMedia(String tagName, long maxId, long minId) {
+	public PagedMediaList getRecentMedia(String tagName, String maxId, String minId) {
 		Map<String,String> params = new HashMap<String,String>();
-		if(maxId > 0) params.put("max_id", Long.toString(maxId));
-		if(minId > 0) params.put("min_id", Long.toString(minId));
+		if(maxId != null) params.put("max_id", maxId);
+		if(minId != null) params.put("min_id", minId);
 		return get(buildUri(TAGS_ENDPOINT + tagName + "/media/recent/", params), PagedMediaList.class);
 	}
 

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/UpdateMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/UpdateMixin.java
@@ -1,0 +1,23 @@
+package org.springframework.social.instagram.api.impl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.springframework.social.instagram.api.Aspect;
+import org.springframework.social.instagram.api.SubscriptionObject;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+abstract class UpdateMixin {
+
+    @JsonCreator
+    public UpdateMixin(
+            @JsonProperty("subscription_id") String subscriptionId,
+            @JsonProperty("object") SubscriptionObject object,
+            @JsonProperty("object_id") String objectId,
+            @JsonProperty("changed_aspect") Aspect changedAspect,
+            @JsonProperty("time") long time) {}
+    
+}
+
+

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/UserTemplate.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/UserTemplate.java
@@ -1,16 +1,16 @@
 package org.springframework.social.instagram.api.impl;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.springframework.social.instagram.api.InstagramProfile;
 import org.springframework.social.instagram.api.PagedMediaList;
 import org.springframework.social.instagram.api.Relationship;
 import org.springframework.social.instagram.api.UserOperations;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link UserOperations}, providing a binding to Instagram's user-oriented REST resources.
@@ -26,45 +26,45 @@ public class UserTemplate extends AbstractInstagramOperations implements UserOpe
 		return get(buildUri(USERS_ENDPOINT + "self/"), InstagramProfileContainer.class).getObject();
 	}
 
-	public InstagramProfile getUser(long userId) {
-		return get(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/"), InstagramProfileContainer.class).getObject();
+	public InstagramProfile getUser(String userId) {
+		return get(buildUri(USERS_ENDPOINT + userId + "/"), InstagramProfileContainer.class).getObject();
 	}
 
 	public PagedMediaList getFeed() {
-		return getFeed(0, 0);
+		return getFeed(null, null);
 	}
 	
-	public PagedMediaList getFeed(long maxId, long minId) {
+	public PagedMediaList getFeed(String maxId, String minId) {
 		requireUserAuthorization();
 		Map<String,String> params = new HashMap<String, String>();
-		if(maxId > 0) params.put("max_id", Long.toString(maxId));
-		if(minId > 0) params.put("min_id", Long.toString(minId));
+		if(maxId != null) params.put("max_id", maxId);
+		if(minId != null) params.put("min_id", minId);
 		return get(buildUri(USERS_ENDPOINT + "self/feed/", params), PagedMediaList.class);
 	}
 
-	public PagedMediaList getRecentMedia(long userId) {
-		return getRecentMedia(userId, 0, 0, 0, 0);
+	public PagedMediaList getRecentMedia(String userId) {
+		return getRecentMedia(userId, null, null, 0, 0);
 	}
 
-	public PagedMediaList getRecentMedia(long userId, long maxId, long minId, long minTimestamp, long maxTimestamp) {
+	public PagedMediaList getRecentMedia(String userId, String maxId, String minId, long minTimestamp, long maxTimestamp) {
 		Map<String,String> params = new HashMap<String, String>();
-		if(maxId > 0) params.put("max_id", Long.toString(maxId));
-		if(maxId > 0) params.put("max_id", Long.toString(maxId));
+		if(maxId != null) params.put("max_id", maxId);
+		if(maxId != null) params.put("max_id", maxId);
 		if(minTimestamp > 0) params.put("min_timestamp", Long.toString(minTimestamp));
 		if(maxTimestamp > 0) params.put("max_timestamp", Long.toString(maxTimestamp));
-		return get(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/media/recent/", params), PagedMediaList.class);
+		return get(buildUri(USERS_ENDPOINT + userId + "/media/recent/", params), PagedMediaList.class);
 	}
 
 	public List<InstagramProfile> search(String query) {
 		return get(buildUri(USERS_ENDPOINT + "search/", Collections.singletonMap("q", query)), InstagramProfileList.class).getList();
 	}
 
-	public List<InstagramProfile> getFollows(long userId) {
-		return get(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/follows/"), InstagramProfileList.class).getList();
+	public List<InstagramProfile> getFollows(String userId) {
+		return get(buildUri(USERS_ENDPOINT + userId + "/follows/"), InstagramProfileList.class).getList();
 	}
 
-	public List<InstagramProfile> getFollowedBy(long userId) {
-		return get(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/followed-by/"), InstagramProfileList.class).getList();
+	public List<InstagramProfile> getFollowedBy(String userId) {
+		return get(buildUri(USERS_ENDPOINT + userId + "/followed-by/"), InstagramProfileList.class).getList();
 	}
 
 	public List<InstagramProfile> getRequestedBy() {
@@ -72,40 +72,40 @@ public class UserTemplate extends AbstractInstagramOperations implements UserOpe
 		return get(buildUri(USERS_ENDPOINT + "self/requested-by/"), InstagramProfileList.class).getList();
 	}
 
-	public Relationship getRelationship(long userId) {
+	public Relationship getRelationship(String userId) {
 		requireUserAuthorization();
-		return get(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/relationship/"), RelationshipContainer.class).getObject();
+		return get(buildUri(USERS_ENDPOINT + userId + "/relationship/"), RelationshipContainer.class).getObject();
 	}
 
-	public void followUser(long userId) {
+	public void followUser(String userId) {
 		modifyRelationship(userId, "follow");
 	}
 
-	public void unfollowUser(long userId) {
+	public void unfollowUser(String userId) {
 		modifyRelationship(userId, "unfollow");
 	}
 
-	public void blockUser(long userId) {
+	public void blockUser(String userId) {
 		modifyRelationship(userId, "block");
 	}
 
-	public void unblockUser(long userId) {
+	public void unblockUser(String userId) {
 		modifyRelationship(userId, "unblock");
 	}
 
-	public void approveUser(long userId) {
+	public void approveUser(String userId) {
 		modifyRelationship(userId, "approve");
 	}
 
-	public void denyUser(long userId) {
+	public void denyUser(String userId) {
 		modifyRelationship(userId, "deny");
 	}
 	
-	private void modifyRelationship(long userId, String action) {
+	private void modifyRelationship(String userId, String action) {
 		requireUserAuthorization();
 		MultiValueMap<String,String> params = new LinkedMultiValueMap<String, String>();
 		params.add("action", action);
-		post(buildUri(USERS_ENDPOINT + Long.toString(userId) + "/relationship/"), params, Map.class);
+		post(buildUri(USERS_ENDPOINT + userId + "/relationship/"), params, Map.class);
 	}
 	
 	

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/VideoMixin.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/api/impl/VideoMixin.java
@@ -4,16 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.springframework.social.instagram.api.Comment;
-
-import java.util.List;
-
 @JsonIgnoreProperties(ignoreUnknown=true)
-abstract class CommentsInfoMixin {
-    @JsonCreator
-    CommentsInfoMixin(
-            @JsonProperty("count") int total,
-            @JsonProperty("data") List<Comment> list) {}
-    
-
+abstract class VideoMixin {
+	@JsonCreator
+	VideoMixin(
+			@JsonProperty("url") String url,
+			@JsonProperty("width") int width,
+			@JsonProperty("height") int height) {}
+	
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/connect/InstagramAdapter.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/connect/InstagramAdapter.java
@@ -24,7 +24,7 @@ public class InstagramAdapter implements ApiAdapter<Instagram> {
 
 	public void setConnectionValues(Instagram instagram, ConnectionValues values) {
 		InstagramProfile profile = instagram.userOperations().getUser();
-		values.setProviderUserId(Long.toString(profile.getId()));
+		values.setProviderUserId(profile.getId());
 		values.setDisplayName(profile.getUsername());
 		values.setImageUrl(profile.getProfilePictureUrl());
 	}
@@ -35,7 +35,7 @@ public class InstagramAdapter implements ApiAdapter<Instagram> {
 	}
 
 	public void updateStatus(Instagram instagram, String message) {
-		// 
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/spring-social-instagram/src/main/java/org/springframework/social/instagram/connect/InstagramOAuth2Template.java
+++ b/spring-social-instagram/src/main/java/org/springframework/social/instagram/connect/InstagramOAuth2Template.java
@@ -1,10 +1,7 @@
 package org.springframework.social.instagram.connect;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Map.Entry;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -13,6 +10,10 @@ import org.springframework.social.oauth2.OAuth2Template;
 import org.springframework.social.support.ClientHttpRequestFactorySelector;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class InstagramOAuth2Template extends OAuth2Template {
 

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/AbstractInstagramApiTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/AbstractInstagramApiTest.java
@@ -7,8 +7,7 @@ import org.junit.Before;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.social.instagram.api.PagedMediaList;
-import org.springframework.social.instagram.api.impl.InstagramTemplate;
-import org.springframework.social.test.client.MockRestServiceServer;
+import org.springframework.test.web.client.MockRestServiceServer;
 
 public abstract class AbstractInstagramApiTest {
 
@@ -27,8 +26,8 @@ public abstract class AbstractInstagramApiTest {
 	}
 	
 	protected void assertPagedResults(PagedMediaList media) {
-		assertEquals(media.getPagination().getNextMaxId(), 5675287);
-		assertEquals(media.getPagination().getNextMinId(), 5689748);
+		assertEquals(media.getPagination().getNextMaxId(), "5675287");
+		assertEquals(media.getPagination().getNextMinId(), "5689748");
 		assertEquals(media.getPagination().getNextUrl(), "https://api.instagram.com/v1/tags/cats/media/recent/?access_token=ACCESS_TOKEN&max_id=5675287");
 		assertTrue(media.getList().size() > 0);
 	}

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/InstagramTemplateTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/InstagramTemplateTest.java
@@ -1,14 +1,14 @@
 package org.springframework.social.instagram.api.impl;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.social.test.client.RequestMatchers.method;
-import static org.springframework.social.test.client.RequestMatchers.requestTo;
-import static org.springframework.social.test.client.ResponseCreators.withResponse;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.social.MissingAuthorizationException;
-import org.springframework.social.test.client.MockRestServiceServer;
+import org.springframework.test.web.client.MockRestServiceServer;
 
 public class InstagramTemplateTest extends AbstractInstagramApiTest {
 	
@@ -19,7 +19,7 @@ public class InstagramTemplateTest extends AbstractInstagramApiTest {
 		
 		server.expect(requestTo("https://api.instagram.com/v1/users/self/?client_id=CLIENT_ID"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/error-response.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/error-response.json", getClass())).headers(responseHeaders));
 		
 		template.userOperations().getUser();
 		mockServer.verify();

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/LocationTemplateTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/LocationTemplateTest.java
@@ -4,9 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.social.test.client.RequestMatchers.method;
-import static org.springframework.social.test.client.RequestMatchers.requestTo;
-import static org.springframework.social.test.client.ResponseCreators.withResponse;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.List;
 
@@ -21,9 +21,9 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void getLocation() {
 	    mockServer.expect(requestTo("https://api.instagram.com/v1/locations/12345/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/location.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/location.json", getClass())).headers(responseHeaders));
 		
-		Location location = instagram.locationOperations().getLocation(12345);
+		Location location = instagram.locationOperations().getLocation("12345");
 		assertEquals(37.782654745657382, location.getLatitude(), 0);
 		mockServer.verify();
 	}
@@ -32,9 +32,9 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void getRecentMedia() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/locations/12345/media/recent/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 		
-		PagedMediaList media = instagram.locationOperations().getRecentMedia(12345);
+		PagedMediaList media = instagram.locationOperations().getRecentMedia("12345");
 		assertPagedResults(media);
 		mockServer.verify();
 	}
@@ -43,9 +43,9 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void getRecentMediaParams() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/locations/12345/media/recent/?access_token=ACCESS_TOKEN&max_id=200&max_timestamp=10000&min_id=100&min_timestamp=5000"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 		
-		PagedMediaList media = instagram.locationOperations().getRecentMedia(12345, 200, 100, 5000, 10000);
+		PagedMediaList media = instagram.locationOperations().getRecentMedia("12345", "200", "100", 5000, 10000);
 		assertPagedResults(media);
 		mockServer.verify();
 	}
@@ -54,7 +54,7 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void search() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/locations/search/?access_token=ACCESS_TOKEN&lng=200.0&lat=100.0"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/location-search.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/location-search.json", getClass())).headers(responseHeaders));
 		
 		List<Location> locations = instagram.locationOperations().search(100, 200);
 		assertTrue(locations.size() > 0);
@@ -65,7 +65,7 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void searchWithDistance() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/locations/search/?access_token=ACCESS_TOKEN&distance=2000&lng=200.0&lat=100.0"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/location-search.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/location-search.json", getClass())).headers(responseHeaders));
 		
 		List<Location> locations = instagram.locationOperations().search(100, 200, 2000);
 		assertTrue(locations.size() > 0);
@@ -76,7 +76,7 @@ public class LocationTemplateTest extends AbstractInstagramApiTest {
 	public void searcgWithFourSquare() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/locations/search/?access_token=ACCESS_TOKEN&foursquare_id=1000"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/location-search.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/location-search.json", getClass())).headers(responseHeaders));
 		
 		List<Location> locations = instagram.locationOperations().search(1000);
 		assertTrue(locations.size() > 0);

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/MediaTemplateTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/MediaTemplateTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.DELETE;
-import static org.springframework.social.test.client.RequestMatchers.body;
-import static org.springframework.social.test.client.RequestMatchers.method;
-import static org.springframework.social.test.client.RequestMatchers.requestTo;
-import static org.springframework.social.test.client.ResponseCreators.withResponse;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.List;
 
@@ -24,10 +24,10 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void getMedia() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/48904105/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media.json", getClass())).headers(responseHeaders));
 		
-		Media media = instagram.mediaOperations().getMedia(48904105);
-		assertEquals(48904105, media.getId());
+		Media media = instagram.mediaOperations().getMedia("48904105");
+		assertEquals("48904105", media.getId());
 		assertTrue(media.getTags().contains("cat") && media.getTags().contains("food"));
 		mockServer.verify();
 	}
@@ -36,7 +36,7 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void getPopular() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/popular/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/media-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media-list.json", getClass())).headers(responseHeaders));
 		
 		List<Media> media = instagram.mediaOperations().getPopular();
 		assertTrue(media.size() > 0);
@@ -47,7 +47,7 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void search() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/search/?access_token=ACCESS_TOKEN&lng=200.0&lat=100.0"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/media-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media-list.json", getClass())).headers(responseHeaders));
 		
 		List<Media> media = instagram.mediaOperations().search(100d, 200d);
 		assertTrue(media.size() > 0);
@@ -58,7 +58,7 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void searchMoreParams() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/search/?access_token=ACCESS_TOKEN&distance=1000&lng=200.0&lat=100.0"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/media-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media-list.json", getClass())).headers(responseHeaders));
 		
 		List<Media> media = instagram.mediaOperations().search(100d, 200d, 1000);
 		assertTrue(media.size() > 0);
@@ -69,7 +69,7 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void searchEvenMoreParams() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/search/?access_token=ACCESS_TOKEN&distance=1000&max_timestamp=1000&lng=200.0&min_timestamp=2000&lat=100.0"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/media-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media-list.json", getClass())).headers(responseHeaders));
 		
 		List<Media> media = instagram.mediaOperations().search(100d, 200d, 1000l, 2000l, 1000);
 		assertTrue(media.size() > 0);
@@ -80,9 +80,9 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void getLikes() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/likes/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-list.json", getClass())).headers(responseHeaders));
 	
-		List<InstagramProfile> likes = instagram.mediaOperations().getLikes(12345);
+		List<InstagramProfile> likes = instagram.mediaOperations().getLikes("12345");
 		assertTrue(likes.size() > 0);
 		mockServer.verify();
 	}
@@ -91,9 +91,9 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void getComments() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/comments/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/comment-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/comment-list.json", getClass())).headers(responseHeaders));
 	
-		List<Comment> comments = instagram.mediaOperations().getComments(12345);
+		List<Comment> comments = instagram.mediaOperations().getComments("12345");
 		assertTrue(comments.size() > 0);
 		mockServer.verify();
 	}
@@ -102,10 +102,10 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void addComment() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/comments/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("text=Awesome%21"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("text=Awesome%21"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 		
-		instagram.mediaOperations().addComment(12345, "Awesome!");
+		instagram.mediaOperations().addComment("12345", "Awesome!");
 		mockServer.verify();
 	}
 	
@@ -113,9 +113,9 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void addLike() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/likes/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 		
-		instagram.mediaOperations().addLike(12345);
+		instagram.mediaOperations().addLike("12345");
 		mockServer.verify();
 	}
 	
@@ -123,9 +123,9 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void deleteComment() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/comments/54321/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(DELETE))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 		
-		instagram.mediaOperations().deleteComment(12345, 54321);
+		instagram.mediaOperations().deleteComment("12345", "54321");
 		mockServer.verify();
 	}
 	
@@ -133,9 +133,9 @@ public class MediaTemplateTest extends AbstractInstagramApiTest {
 	public void deleteLike() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/media/12345/likes/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(DELETE))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 		
-		instagram.mediaOperations().deleteLike(12345);
+		instagram.mediaOperations().deleteLike("12345");
 		mockServer.verify();
 	}
 }

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/TagTemplateTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/TagTemplateTest.java
@@ -1,9 +1,9 @@
 package org.springframework.social.instagram.api.impl;
 
 import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.social.test.client.RequestMatchers.method;
-import static org.springframework.social.test.client.RequestMatchers.requestTo;
-import static org.springframework.social.test.client.ResponseCreators.withResponse;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class TagTemplateTest extends AbstractInstagramApiTest {
 	public void getTag() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/tags/cats/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/tag.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/tag.json", getClass())).headers(responseHeaders));
 		
 		Tag tag = instagram.tagOperations().getTag("cats");
 		mockServer.verify();
@@ -29,7 +29,7 @@ public class TagTemplateTest extends AbstractInstagramApiTest {
 	public void searchTags() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/tags/search/?access_token=ACCESS_TOKEN&q=cats"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/tag-search.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/tag-search.json", getClass())).headers(responseHeaders));
 		
 		List<Tag> tags = instagram.tagOperations().search("cats");
 		mockServer.verify();
@@ -39,7 +39,7 @@ public class TagTemplateTest extends AbstractInstagramApiTest {
 	public void recentMedia() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/tags/cats/media/recent/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 		
 		PagedMediaList media = instagram.tagOperations().getRecentMedia("cats");
 		assertPagedResults(media);
@@ -50,9 +50,9 @@ public class TagTemplateTest extends AbstractInstagramApiTest {
 	public void recentMediaParams() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/tags/cats/media/recent/?access_token=ACCESS_TOKEN&max_id=100&min_id=200"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 		
-		PagedMediaList media = instagram.tagOperations().getRecentMedia("cats", 100, 200);
+		PagedMediaList media = instagram.tagOperations().getRecentMedia("cats", "100", "200");
 		assertPagedResults(media);
 		mockServer.verify();
 	}

--- a/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/UserTemplateTest.java
+++ b/spring-social-instagram/src/test/java/org/springframework/social/instagram/api/impl/UserTemplateTest.java
@@ -5,10 +5,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
-import static org.springframework.social.test.client.RequestMatchers.body;
-import static org.springframework.social.test.client.RequestMatchers.method;
-import static org.springframework.social.test.client.RequestMatchers.requestTo;
-import static org.springframework.social.test.client.ResponseCreators.withResponse;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.List;
 
@@ -24,7 +24,7 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/self/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-profile.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-profile.json", getClass())).headers(responseHeaders));
 		
 		InstagramProfile user = instagram.userOperations().getUser();
 		assertEquals("tomharman", user.getUsername());
@@ -35,9 +35,9 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getSpecificUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-profile.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-profile.json", getClass())).headers(responseHeaders));
 		
-		InstagramProfile user = instagram.userOperations().getUser(12345);
+		InstagramProfile user = instagram.userOperations().getUser("12345");
 		assertEquals("tomharman", user.getUsername());
 		mockServer.verify();
 	}
@@ -46,7 +46,7 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getFeed() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/self/feed/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 		
 		PagedMediaList media = instagram.userOperations().getFeed();
 		assertPagedResults(media);
@@ -57,9 +57,9 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getRecentMedia() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/media/recent/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/recent-media.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/recent-media.json", getClass())).headers(responseHeaders));
 	
-		PagedMediaList media = instagram.userOperations().getRecentMedia(12345);
+		PagedMediaList media = instagram.userOperations().getRecentMedia("12345");
 		assertPagedResults(media);
 		mockServer.verify();
 	}
@@ -68,9 +68,9 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getFollowedBy() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/followed-by/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-list.json", getClass())).headers(responseHeaders));
 		
-		List<InstagramProfile> follows = instagram.userOperations().getFollowedBy(12345);
+		List<InstagramProfile> follows = instagram.userOperations().getFollowedBy("12345");
 		assertTrue(follows.size() > 0);
 		mockServer.verify();
 	}
@@ -79,9 +79,9 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getFollows() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/follows/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-list.json", getClass())).headers(responseHeaders));
 		
-		List<InstagramProfile> follows = instagram.userOperations().getFollows(12345);
+		List<InstagramProfile> follows = instagram.userOperations().getFollows("12345");
 		assertTrue(follows.size() > 0);
 		mockServer.verify();
 	}
@@ -90,7 +90,7 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getRequestedBy() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/self/requested-by/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/user-list.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/user-list.json", getClass())).headers(responseHeaders));
 		
 		List<InstagramProfile> follows = instagram.userOperations().getRequestedBy();
 		assertTrue(follows.size() > 0);
@@ -101,9 +101,9 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void getRelationship() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(GET))
-			.andRespond(withResponse(new ClassPathResource("testdata/relationship.json", getClass()), responseHeaders));
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/relationship.json", getClass())).headers(responseHeaders));
 	
-		Relationship relationship = instagram.userOperations().getRelationship(12345);
+		Relationship relationship = instagram.userOperations().getRelationship("12345");
 		assertNotNull(relationship.getIncomingStatus());
 		assertNotNull(relationship.getOutgoingStatus());
 		mockServer.verify();
@@ -113,10 +113,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void followUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=follow"))
-			.andRespond(withResponse(new ClassPathResource("testdata/media-list.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=follow"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/media-list.json", getClass())).headers(responseHeaders));
 		
-		instagram.userOperations().followUser(12345);
+		instagram.userOperations().followUser("12345");
 		mockServer.verify();
 	}
 	
@@ -124,10 +124,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void unfollowUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=unfollow"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=unfollow"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 
-		instagram.userOperations().unfollowUser(12345);
+		instagram.userOperations().unfollowUser("12345");
 		mockServer.verify();
 	}
 	
@@ -135,10 +135,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void blockUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=block"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=block"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 		
-		instagram.userOperations().blockUser(12345);
+		instagram.userOperations().blockUser("12345");
 		mockServer.verify();
 	}
 	
@@ -146,10 +146,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void unblockUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=unblock"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=unblock"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 
-		instagram.userOperations().unblockUser(12345);
+		instagram.userOperations().unblockUser("12345");
 		mockServer.verify();
 	}
 	
@@ -157,10 +157,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void approveUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=approve"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=approve"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 
-		instagram.userOperations().approveUser(12345);
+		instagram.userOperations().approveUser("12345");
 		mockServer.verify();
 	}
 	
@@ -168,10 +168,10 @@ public class UserTemplateTest extends AbstractInstagramApiTest {
 	public void denyUser() {
 		mockServer.expect(requestTo("https://api.instagram.com/v1/users/12345/relationship/?access_token=ACCESS_TOKEN"))
 			.andExpect(method(POST))
-			.andExpect(body("action=deny"))
-			.andRespond(withResponse(new ClassPathResource("testdata/ok-response.json", getClass()), responseHeaders));
+			.andExpect(content().string("action=deny"))
+			.andRespond(withSuccess().body(new ClassPathResource("testdata/ok-response.json", getClass())).headers(responseHeaders));
 
-		instagram.userOperations().denyUser(12345);
+		instagram.userOperations().denyUser("12345");
 		mockServer.verify();
 	}
 }


### PR DESCRIPTION
... videos; use String for keys instead of int;

I'm not terribly Gradle savvy, so I left most of that alone. I notice, though, that other Spring Gradle projects are moving away from the submodule model.

A bit of work remains to bring it up to full Spring Social 1.1 compliance, like schema and Java config support.

Please let me know if you intend to use this patch or whether I should move forward with my own fork. Thanks for your efforts and I hope this is of use to someone else...
